### PR TITLE
Check if the contact exists prior to upserting/creating

### DIFF
--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -57,7 +57,7 @@ JS.class(ClientSuccessClient, {
 		 */
 		hitClientSuccessAPI : async function(method, path, data) {
 			if (!method) {
-				throw new Error('method required');
+				throw new CustomError({ status : 400, message : 'API Method Required' });
 			}
 
 			// Retry for block to re-attempt API call if an expired token is encountered
@@ -91,12 +91,11 @@ JS.class(ClientSuccessClient, {
 					}
 					else {
 						// Package up the resulting API error for the function caller to handle on the other end
-						throw error;
+						throw new CustomError({ status : error.response.status, message : error.response.message });
 					}
 				}
 			}
-
-			throw new CustomError(429, 'Too Many Requests');
+			throw new CustomError({ status : 429, message : 'Too Many Requests' });
 		},
 
 		/**
@@ -138,7 +137,7 @@ JS.class(ClientSuccessClient, {
 				}
 				catch (error) {
 					if (error.status !== 404) {
-						throw error;
+						throw new CustomError({ status : error.status, message : error.message });
 					}
 					// Else, user was not found, therefore continue to creation
 				}
@@ -220,7 +219,7 @@ JS.class(ClientSuccessClient, {
 		 */
 		getContactByEmail : async function(clientExternalId, contactEmail) {
 			if (!clientExternalId || !contactEmail) {
-				throw new Error('Invalid clientExternalId or contactEmail for getContactByEmail');
+				throw new CustomError({ status : 400, message : 'Invalid clientExternalId or contactEmail for getContactByEmail' });
 			}
 
 			const foundContact = await this.hitClientSuccessAPI(

--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -290,7 +290,12 @@ JS.class(ClientSuccessClient, {
 				}
 				catch (error) {
 					// contact not found, therefore create it
-					contact = await this.createContact(clientId, attributes, customAttributes);
+					if (error.status === 404) {
+						contact = await this.createContact(clientId, attributes, customAttributes);
+					}
+					else {
+						throw new CustomError({ status : error.status, message : error.message });
+					}
 				}
 
 				contactId = contact.id;

--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -215,7 +215,7 @@ JS.class(ClientSuccessClient, {
 		 * Preferred to pull by ClientSuccess Client ID, but this method is not supported yet.
 		 * @param  {String} clientExternalId - Client External ID of the Client to be searched
 		 * @param  {String} contactEmail     - Email of the Contact
-		 * @return {Object}                  - Contact Object of the found contact
+		 * @return Promise<Object>           - Contact Object of the found contact
 		 */
 		getContactByEmail : async function(clientExternalId, contactEmail) {
 			if (!clientExternalId || !contactEmail) {
@@ -232,7 +232,6 @@ JS.class(ClientSuccessClient, {
 			}
 
 			return foundContact;
-
 		},
 
 		/**
@@ -275,7 +274,7 @@ JS.class(ClientSuccessClient, {
 		/**
 		 * Creates or updates a Contact based on the attributes provided
 		 * @param  {String} clientId         ClientSuccess ID of the Client that will contain the Contact
-		 * @param  {String} contactId        (Optional) if provided, it will trigger an update, else it will create a new Contact
+		 * @param  {String} [contactId]      If provided, it will trigger an update, else it will create a new Contact
 		 * @param  {Object} attributes       ClientSuccess native Contact attributes to fill
 		 * @param  {Object} customAttributes ClientSuccess Contact custom attributes to fill
 		 * @return {Object}                  Resulting Contact data object
@@ -288,14 +287,13 @@ JS.class(ClientSuccessClient, {
 				const client = await this.getClient(clientId);
 				try {
 					contact = await this.getContactByEmail(client.externalId, attributes.email);
-					// found existing contact
 				}
 				catch (error) {
 					// contact not found, therefore create it
 					contact = await this.createContact(clientId, attributes, customAttributes);
 				}
 
-				contactId     = contact.id;
+				contactId = contact.id;
 				let updateContactAttributes = Object.assign({}, contact); // clone the client object for comparison purposes
 				if (!_.get(updateContactAttributes, 'customFieldValues[0]')) {
 					// The ClientSuccess create contact API does not return back clean custom attributes, only null values

--- a/test/tests.js
+++ b/test/tests.js
@@ -75,7 +75,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should create a new test client', async function() {
-			const newUserName = `TEST user ${(new Date()).getTime()}`;
+			const newUserName = `${(new Date()).getTime()}`;
 
 			const testClientAttributes = {
 				name : newUserName,
@@ -88,7 +88,7 @@ describe('clientSuccessClient', function() {
 
 		it('should error on invalid data', async function() {
 			if (runWriteTests) {
-				const newUserName = `TEST user ${(new Date()).getTime()}`;
+				const newUserName = `${(new Date()).getTime()}`;
 
 				const testClientAttributes = {
 					name     : newUserName,
@@ -99,7 +99,7 @@ describe('clientSuccessClient', function() {
 			}
 		});
 		it('should not create a brand new Client, but should update the existing when creating a Client with matching External ID as an existing Client', async function() {
-			const testUserName1 = `TEST user ${(new Date()).getTime()}`;
+			const testUserName1 = `${(new Date()).getTime()}`;
 			const testExternalID     = `${(new Date()).getTime()}test`;
 
 			const testClientAttributesInitial1 = {
@@ -123,7 +123,7 @@ describe('clientSuccessClient', function() {
 
 		it('should create a new fresh Client with custom attribtues', async function() {
 			this.timeout(15000);
-			const newUserName = `TEST user ${(new Date()).getTime()}`;
+			const newUserName = `${(new Date()).getTime()}`;
 			const testExternalID     = `${(new Date()).getTime()}test2`;
 
 			const testClientAttributes = {
@@ -147,11 +147,11 @@ describe('clientSuccessClient', function() {
 
 	describe('updateClient', async function() {
 		let testClient;
-		const testUserName = `TEST user ${(new Date()).getTime()}`;
+		const testUserName = `${(new Date()).getTime()}`;
 
 		before(async function() {
 			// create a test client with initial attributes to use in updateClient tests
-			const testUserName = `TEST user ${(new Date()).getTime()}`;
+			const testUserName = `${(new Date()).getTime()}`;
 
 			const testClientAttributesInitial = {
 				name : testUserName,
@@ -242,7 +242,7 @@ describe('clientSuccessClient', function() {
 
 		before(async function() {
 			// create a test client with initial attributes to use in updateClient tests
-			const testClientName = `TEST user ${(new Date()).getTime()}`;
+			const testClientName = `${(new Date()).getTime()}`;
 
 			const testClientAttributesInitial = {
 				name : testClientName,
@@ -264,7 +264,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should automatically create a Client if there is an undefined clientId present in the function arguments', async function() {
-			const upsertedClientTestName = `TEST user ${(new Date()).getTime()}`;
+			const upsertedClientTestName = `${(new Date()).getTime()}`;
 			upsertedClient = await CS.upsertClient({
 				clientId   : undefined,
 				attributes : {
@@ -276,7 +276,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should automatically create a Client if there is a blank clientId present in the function arguments', async function() {
-			const upsertedClientTestName = `TEST user ${(new Date()).getTime()}`;
+			const upsertedClientTestName = `${(new Date()).getTime()}`;
 			upsertedClient = await CS.upsertClient({
 				clientId   : '',
 				attributes : {
@@ -288,7 +288,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should automatically create a Client if only attributes are passed in', async function() {
-			const upsertedClientTestName = `TEST user ${(new Date()).getTime()}`;
+			const upsertedClientTestName = `${(new Date()).getTime()}`;
 			upsertedClient = await CS.upsertClient({
 				attributes : {
 					name : upsertedClientTestName,
@@ -348,7 +348,7 @@ describe('clientSuccessClient', function() {
 		it('should return back the object of an existing contact', async function() {
 			if (runWriteTests) {
 				// create test client
-				const newClientName = `TEST client ${(new Date()).getTime()}`;
+				const newClientName = `${(new Date()).getTime()}`;
 				const testClientAttributes = {
 					name : newClientName,
 				};
@@ -356,7 +356,7 @@ describe('clientSuccessClient', function() {
 				// add the clientID to be cleaned up later
 				createdTestUsers.push(testClient.id);
 
-				const newContactName = `TEST user ${(new Date()).getTime()}`;
+				const newContactName = `${(new Date()).getTime()}`;
 
 				// create a new contact in this test client
 				const testContactAttributes = {
@@ -386,7 +386,7 @@ describe('clientSuccessClient', function() {
 
 		before(async function() {
 			this.timeout(15000);
-			const newClientName = `TEST client ${(new Date()).getTime()}`;
+			const newClientName = `${(new Date()).getTime()}`;
 			const testExternalID     = `${(new Date()).getTime()}test`;
 			const testClientAttributes = {
 				name       : newClientName,
@@ -402,7 +402,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should find a contact that contains a plus sign', async function() {
-			const newContactName = `TEST user ${(new Date()).getTime()}`;
+			const newContactName = `${(new Date()).getTime()}`;
 			const newContactEmail = 'testemail+plus@dev.roadmunk.com';
 			const testContactAttributes = {
 				firstName : newContactName,
@@ -431,7 +431,7 @@ describe('clientSuccessClient', function() {
 		let testClient;
 
 		before(async function() {
-			const newClientName = `TEST client ${(new Date()).getTime()}`;
+			const newClientName = `${(new Date()).getTime()}`;
 			const testClientAttributes = {
 				name : newClientName,
 			};
@@ -445,7 +445,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should create a new test contact', async function() {
-			const newContactName = `TEST user ${(new Date()).getTime()}`;
+			const newContactName = `${(new Date()).getTime()}`;
 			const testContactAttributes = {
 				firstName : newContactName,
 				lastName  : newContactName,
@@ -457,7 +457,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should create a contact with custom attributes passed', async function() {
-			const newContactName = `TEST user ${(new Date()).getTime()}`;
+			const newContactName = `${(new Date()).getTime()}`;
 			const testExternalID      = `${(new Date()).getTime()}test`;
 
 			const testContactAttributes = {
@@ -487,14 +487,14 @@ describe('clientSuccessClient', function() {
 		let newContactName;
 
 		before(async function() {
-			const newClientName = `TEST client ${(new Date()).getTime()}`;
+			const newClientName = `${(new Date()).getTime()}`;
 			const testClientAttributes = {
 				name : newClientName,
 			};
 
 			testClient = await CS.createClient(testClientAttributes);
 
-			newContactName = `TEST user ${(new Date()).getTime()}`;
+			newContactName = `${(new Date()).getTime()}`;
 
 			const testContactAttributes = {
 				firstName : newContactName,
@@ -552,7 +552,7 @@ describe('clientSuccessClient', function() {
 		let newContactName;
 
 		before(async function() {
-			const newClientName = `TEST client ${(new Date()).getTime()}`;
+			const newClientName = `${(new Date()).getTime()}`;
 			const testExternalID     = `${(new Date()).getTime()}test`;
 			const testClientAttributes = {
 				name       : newClientName,
@@ -561,7 +561,7 @@ describe('clientSuccessClient', function() {
 
 			testClient = await CS.createClient(testClientAttributes);
 
-			newContactName = `TEST user ${(new Date()).getTime()}`;
+			newContactName = `${(new Date()).getTime()}`;
 
 			const testContactAttributes = {
 				firstName : newContactName,
@@ -576,7 +576,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should automatically create a Contact if there is an undefined contactId present in the function arguments', async function() {
-			const upsertedContactTestName = `TEST${(new Date()).getTime()}`;
+			const upsertedContactTestName = `${(new Date()).getTime()}`;
 			const upsertedContact = await CS.upsertContact({
 				clientId   : testClient.id,
 				attributes : {
@@ -590,7 +590,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should automatically create a Contact if there is a blank contactId present in the function arguments', async function() {
-			const upsertedContactTestName = `TEST${(new Date()).getTime()}test2`;
+			const upsertedContactTestName = `${(new Date()).getTime()}`;
 			const upsertedContact = await CS.upsertContact({
 				clientId   : testClient.id,
 				contactId  : '',
@@ -605,7 +605,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should automatically create a Contact if only attributes are passed in', async function() {
-			const upsertedContactTestName = `TEST${(new Date()).getTime()}test3`;
+			const upsertedContactTestName = `${(new Date()).getTime()}`;
 			const upsertedContact = await CS.upsertContact({
 				clientId   : testClient.id,
 				attributes : {
@@ -619,7 +619,7 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should update an existing Contact if a contactId is passed', async function() {
-			const upsertedContactTestName = `TEST${(new Date()).getTime()}test4`;
+			const upsertedContactTestName = `${(new Date()).getTime()}`;
 			const upsertedContact = await CS.upsertContact({
 				clientId   : testClient.id,
 				contactId  : testContact.id,
@@ -635,15 +635,14 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should create a new Contact with custom attributes', async function() {
-			const upsertedContactTestName = `TEST${(new Date()).getTime()}test5`;
-			const testExternalID               = `${(new Date()).getTime()}test`;
+			const upsertedContactTestName = `${(new Date()).getTime()}`;
 			const contactAttributes = {
 				firstName : upsertedContactTestName,
 				lastName  : upsertedContactTestName,
 				email     : `${upsertedContactTestName}@dev.roadmunk.com`,
 			};
 			const contactCustomAttributes = {
-				'External ID' : testExternalID,
+				'External ID' : upsertedContactTestName,
 			};
 			let upsertedContact = await CS.upsertContact({
 				clientId         : testClient.id,
@@ -654,19 +653,18 @@ describe('clientSuccessClient', function() {
 			upsertedContact = await CS.getContact(testClient.id, upsertedContact.id);
 			expect(upsertedContact.firstName).to.equal(upsertedContactTestName);
 			expect(upsertedContact.lastName).to.equal(upsertedContactTestName);
-			expect(upsertedContact.customFieldValues[1].value).to.equal(testExternalID);
+			expect(upsertedContact.customFieldValues[1].value).to.equal(upsertedContactTestName);
 		});
 
 		it('should update an existing Contact with custom attribtues', async function() {
-			const upsertedContactTestName = `TEST${(new Date()).getTime()}test6`;
-			const testExternalID               = `${(new Date()).getTime()}test`;
+			const upsertedContactTestName = `${(new Date()).getTime()}`;
 			const newContactAttributes = {
 				firstName : `${upsertedContactTestName}updated`,
 				lastName  : `${upsertedContactTestName}updated`,
 				email     : `${upsertedContactTestName}@dev.roadmunk.com`,
 			};
 			const newContactCustomAttributes = {
-				'External ID' : `${testExternalID}updated`,
+				'External ID' : `${upsertedContactTestName}updated`,
 			};
 			let upsertedContact = await CS.upsertContact({
 				clientId         : testClient.id,
@@ -679,11 +677,11 @@ describe('clientSuccessClient', function() {
 			expect(upsertedContact.id).to.equal(testContact.id);
 			expect(upsertedContact.firstName).to.equal(`${upsertedContactTestName}updated`);
 			expect(upsertedContact.lastName).to.equal(`${upsertedContactTestName}updated`);
-			expect(upsertedContact.customFieldValues[1].value).to.equal(`${testExternalID}updated`);
+			expect(upsertedContact.customFieldValues[1].value).to.equal(`${upsertedContactTestName}updated`);
 		});
 
 		it('should not create a new contact if it has already been created under this client', async function() {
-			const newContactName  = `TEST user ${(new Date()).getTime()}`;
+			const newContactName  = `${(new Date()).getTime()}`;
 			const newContactEmail = `testuser${(new Date()).getTime()}@dev.roadmunk.com`;
 
 			const testContactAttributes = {

--- a/test/tests.js
+++ b/test/tests.js
@@ -8,13 +8,6 @@ const config = require('./config');
 
 chai.use(require('chai-as-promised'));
 
-const customTimeout = ms => new Promise(res => setTimeout(res, ms));
-
-// process.on('unhandledRejection', (reason, p) => {
-//	console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
-//	// application specific logging, throwing an error, or other logic here
-// });
-
 describe('clientSuccessClient', function() {
 
 	const runWriteTests = true; // true = run all tests that reach out and write to ClientSuccess

--- a/test/tests.js
+++ b/test/tests.js
@@ -81,10 +81,9 @@ describe('clientSuccessClient', function() {
 				name : newUserName,
 			};
 
-			// create the test client
 			testClient = await CS.createClient(testClientAttributes);
 
-			expect(testClient.id).to.be.a('number');
+			expect(testClient.name).to.equal(newUserName);
 		});
 
 		it('should error on invalid data', async function() {
@@ -101,11 +100,11 @@ describe('clientSuccessClient', function() {
 		});
 		it('should not create a brand new Client, but should update the existing when creating a Client with matching External ID as an existing Client', async function() {
 			const testUserName1 = `TEST user ${(new Date()).getTime()}`;
-			const testExtID     = `${(new Date()).getTime()}test`;
+			const testExternalID     = `${(new Date()).getTime()}test`;
 
 			const testClientAttributesInitial1 = {
 				name       : testUserName1,
-				externalId : testExtID,
+				externalId : testExternalID,
 			};
 
 			testClient = await CS.createClient(testClientAttributesInitial1);
@@ -113,7 +112,7 @@ describe('clientSuccessClient', function() {
 			const testUserName2 = `TEST user ${(new Date()).getTime()}2`;
 			const testClientAttributesInitial2 = {
 				name       : testUserName2,
-				externalId : testExtID,
+				externalId : testExternalID,
 			};
 
 			const testClient2 = await CS.createClient(testClientAttributesInitial2);
@@ -125,18 +124,17 @@ describe('clientSuccessClient', function() {
 		it('should create a new fresh Client with custom attribtues', async function() {
 			this.timeout(15000);
 			const newUserName = `TEST user ${(new Date()).getTime()}`;
-			const testExtID     = `${(new Date()).getTime()}test2`;
+			const testExternalID     = `${(new Date()).getTime()}test2`;
 
 			const testClientAttributes = {
 				name       : newUserName,
-				externalId : testExtID,
+				externalId : testExternalID,
 			};
 
 			const testClientCustomAttributes = {
 				'Account Notes' : `${newUserName} note`,
 			};
 
-			// create the test client
 			testClient = await CS.createClient(testClientAttributes, testClientCustomAttributes);
 
 			const createdCustomUser = await CS.getClient(testClient.id);
@@ -238,7 +236,6 @@ describe('clientSuccessClient', function() {
 	});
 
 	describe('upsertClient', async function() {
-		// we will use a test client
 		let testClient;
 		let upsertedClient;
 		const upsertedClientArray = [];
@@ -355,12 +352,10 @@ describe('clientSuccessClient', function() {
 				const testClientAttributes = {
 					name : newClientName,
 				};
-				// create the test client
 				const testClient = await CS.createClient(testClientAttributes);
-				// add the clientIc to be cleaned up later
+				// add the clientID to be cleaned up later
 				createdTestUsers.push(testClient.id);
 
-				// create a test client
 				const newContactName = `TEST user ${(new Date()).getTime()}`;
 
 				// create a new contact in this test client
@@ -369,12 +364,11 @@ describe('clientSuccessClient', function() {
 					lastName  : newContactName,
 				};
 
-				// create the test client
 				const testContact = await CS.createContact(testClient.id, testContactAttributes);
 
 				const foundContact = await CS.getContact(testContact.clientId, testContact.id);
 
-				expect(foundContact.id).to.be.a('number');
+				expect(foundContact.id).to.equal(testContact.id);
 			}
 		});
 
@@ -392,14 +386,13 @@ describe('clientSuccessClient', function() {
 
 		before(async function() {
 			this.timeout(15000);
-			// create test client
 			const newClientName = `TEST client ${(new Date()).getTime()}`;
-			const testExtID     = `${(new Date()).getTime()}test`;
+			const testExternalID     = `${(new Date()).getTime()}test`;
 			const testClientAttributes = {
 				name       : newClientName,
-				externalId : testExtID,
+				externalId : testExternalID,
 			};
-			// create the test client
+
 			testClient = await CS.createClient(testClientAttributes);
 		});
 
@@ -409,20 +402,18 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should find a contact that contains a plus sign', async function() {
-			// create a test contact
 			const newContactName = `TEST user ${(new Date()).getTime()}`;
-			const newContactEmail = 'testemail+plus@roadmunk.com';
+			const newContactEmail = 'testemail+plus@dev.roadmunk.com';
 			const testContactAttributes = {
 				firstName : newContactName,
 				lastName  : newContactName,
 				email     : newContactEmail,
 			};
 			const testContact = await CS.createContact(testClient.id, testContactAttributes);
-
-			// try grabbing the contact
 			const foundContact = await CS.getContactByEmail(testClient.externalId, testContact.email);
 
 			expect(foundContact.id).to.equal(testContact.id);
+			expect(foundContact.email).to.equal(testContact.email);
 		});
 
 		it('should return a 404 if the contact does not exist', async function() {
@@ -436,16 +427,15 @@ describe('clientSuccessClient', function() {
 	});
 
 	describe('createContact', async function() {
+		this.timeout(15000);
 		let testClient;
 
 		before(async function() {
-			this.timeout(15000);
-			// create test client
 			const newClientName = `TEST client ${(new Date()).getTime()}`;
 			const testClientAttributes = {
 				name : newClientName,
 			};
-				// create the test client
+
 			testClient = await CS.createClient(testClientAttributes);
 		});
 
@@ -455,7 +445,6 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should create a new test contact', async function() {
-			// create a test contact
 			const newContactName = `TEST user ${(new Date()).getTime()}`;
 			const testContactAttributes = {
 				firstName : newContactName,
@@ -463,16 +452,14 @@ describe('clientSuccessClient', function() {
 			};
 			const testContact = await CS.createContact(testClient.id, testContactAttributes);
 
-			expect(testContact.id).to.be.a('number');
+			expect(testContact.firstName).to.equal(newContactName);
+			expect(testContact.lastName).to.equal(newContactName);
 		});
 
 		it('should create a contact with custom attributes passed', async function() {
-			this.timeout(15000);
-			// create a test contact
 			const newContactName = `TEST user ${(new Date()).getTime()}`;
-			const testExtID      = `${(new Date()).getTime()}test`;
+			const testExternalID      = `${(new Date()).getTime()}test`;
 
-			// create a new contact in this test contac5
 			const testContactAttributes = {
 				firstName : newContactName,
 				lastName  : newContactName,
@@ -480,46 +467,40 @@ describe('clientSuccessClient', function() {
 
 			// new contact custom attributes to set
 			const testContactCustomAttributes = {
-				'External ID' : testExtID,
+				'External ID' : testExternalID,
 			};
 
-			// create the test contact
 			let testContact = await CS.createContact(testClient.id, testContactAttributes, testContactCustomAttributes);
 
 			// pull down the contact detail model
 			testContact = await CS.getContact(testContact.clientId, testContact.id);
-			expect(testContact.customFieldValues[1].value).to.equal(testExtID);
+			expect(testContact.customFieldValues[1].value).to.equal(testExternalID);
 		});
 
 		it('should error on invalid data');
 	});
 
 	describe('updateContact', function() {
+		this.timeout(15000);
 		let testClient;
 		let testContact;
 		let newContactName;
 
 		before(async function() {
-			// create a test client to work with
-			this.timeout(15000);
-			// create test client
 			const newClientName = `TEST client ${(new Date()).getTime()}`;
 			const testClientAttributes = {
 				name : newClientName,
 			};
-			// create the test client
+
 			testClient = await CS.createClient(testClientAttributes);
 
-			// create a test client
 			newContactName = `TEST user ${(new Date()).getTime()}`;
 
-			// create a new contact in this test client
 			const testContactAttributes = {
 				firstName : newContactName,
 				lastName  : newContactName,
 			};
 
-			// create the test client
 			testContact = await CS.createContact(testClient.id, testContactAttributes);
 		});
 
@@ -541,13 +522,13 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should update a contact with custom attributes passed in', async function() {
-			const testExtID                = `${(new Date()).getTime()}test`;
+			const testExternalID           = `${(new Date()).getTime()}test`;
 			const testContactAttributesNew = {
 				firstName : `${newContactName}updated`,
 			};
 
 			const testContactCustomAttributesNew = {
-				'External ID' : testExtID,
+				'External ID' : testExternalID,
 			};
 
 			let updatedContact = await CS.updateContact(testContact.clientId, testContact.id, testContactAttributesNew, testContactCustomAttributesNew);
@@ -556,7 +537,7 @@ describe('clientSuccessClient', function() {
 			updatedContact = await CS.getContact(testContact.clientId, testContact.id);
 
 			// verify that client has been updated
-			expect(updatedContact.customFieldValues[1].value).to.equal(testExtID);
+			expect(updatedContact.customFieldValues[1].value).to.equal(testExternalID);
 		});
 
 		it('should error when we pass an invalid data type in', async function() {
@@ -571,31 +552,26 @@ describe('clientSuccessClient', function() {
 		let newContactName;
 
 		before(async function() {
-			// create test client
 			const newClientName = `TEST client ${(new Date()).getTime()}`;
-			const testExtID     = `${(new Date()).getTime()}test`;
+			const testExternalID     = `${(new Date()).getTime()}test`;
 			const testClientAttributes = {
 				name       : newClientName,
-				externalId : testExtID,
+				externalId : testExternalID,
 			};
-			// create the test client
+
 			testClient = await CS.createClient(testClientAttributes);
 
-			// create a test client
 			newContactName = `TEST user ${(new Date()).getTime()}`;
 
-			// create a new contact in this test client
 			const testContactAttributes = {
 				firstName : newContactName,
 				lastName  : newContactName,
 			};
 
-			// create the test client
 			testContact = await CS.createContact(testClient.id, testContactAttributes);
 		});
 
 		after(async function() {
-			// clean the test client
 			CS.closeClient(testClient.id);
 		});
 
@@ -606,7 +582,7 @@ describe('clientSuccessClient', function() {
 				attributes : {
 					firstName : upsertedContactTestName,
 					lastName  : upsertedContactTestName,
-					email     : `${upsertedContactTestName}@roadmunk.com`,
+					email     : `${upsertedContactTestName}@dev.roadmunk.com`,
 				},
 			});
 			expect(upsertedContact.firstName).to.equal(upsertedContactTestName);
@@ -621,7 +597,7 @@ describe('clientSuccessClient', function() {
 				attributes : {
 					firstName : upsertedContactTestName,
 					lastName  : upsertedContactTestName,
-					email     : `${upsertedContactTestName}@roadmunk.com`,
+					email     : `${upsertedContactTestName}@dev.roadmunk.com`,
 				},
 			});
 			expect(upsertedContact.firstName).to.equal(upsertedContactTestName);
@@ -635,7 +611,7 @@ describe('clientSuccessClient', function() {
 				attributes : {
 					firstName : upsertedContactTestName,
 					lastName  : upsertedContactTestName,
-					email     : `${upsertedContactTestName}@roadmunk.com`,
+					email     : `${upsertedContactTestName}@dev.roadmunk.com`,
 				},
 			});
 			expect(upsertedContact.firstName).to.equal(upsertedContactTestName);
@@ -650,7 +626,7 @@ describe('clientSuccessClient', function() {
 				attributes : {
 					firstName : upsertedContactTestName,
 					lastName  : upsertedContactTestName,
-					email     : `${upsertedContactTestName}@roadmunk.com`,
+					email     : `${upsertedContactTestName}@dev.roadmunk.com`,
 				},
 			});
 			expect(upsertedContact.id).to.equal(testContact.id);
@@ -660,14 +636,14 @@ describe('clientSuccessClient', function() {
 
 		it('should create a new Contact with custom attributes', async function() {
 			const upsertedContactTestName = `TEST${(new Date()).getTime()}test5`;
-			const testExtID               = `${(new Date()).getTime()}test`;
+			const testExternalID               = `${(new Date()).getTime()}test`;
 			const contactAttributes = {
 				firstName : upsertedContactTestName,
 				lastName  : upsertedContactTestName,
-				email     : `${upsertedContactTestName}@roadmunk.com`,
+				email     : `${upsertedContactTestName}@dev.roadmunk.com`,
 			};
 			const contactCustomAttributes = {
-				'External ID' : testExtID,
+				'External ID' : testExternalID,
 			};
 			let upsertedContact = await CS.upsertContact({
 				clientId         : testClient.id,
@@ -678,19 +654,19 @@ describe('clientSuccessClient', function() {
 			upsertedContact = await CS.getContact(testClient.id, upsertedContact.id);
 			expect(upsertedContact.firstName).to.equal(upsertedContactTestName);
 			expect(upsertedContact.lastName).to.equal(upsertedContactTestName);
-			expect(upsertedContact.customFieldValues[1].value).to.equal(testExtID);
+			expect(upsertedContact.customFieldValues[1].value).to.equal(testExternalID);
 		});
 
 		it('should update an existing Contact with custom attribtues', async function() {
 			const upsertedContactTestName = `TEST${(new Date()).getTime()}test6`;
-			const testExtID               = `${(new Date()).getTime()}test`;
+			const testExternalID               = `${(new Date()).getTime()}test`;
 			const newContactAttributes = {
 				firstName : `${upsertedContactTestName}updated`,
 				lastName  : `${upsertedContactTestName}updated`,
-				email     : `${upsertedContactTestName}@roadmunk.com`,
+				email     : `${upsertedContactTestName}@dev.roadmunk.com`,
 			};
 			const newContactCustomAttributes = {
-				'External ID' : `${testExtID}updated`,
+				'External ID' : `${testExternalID}updated`,
 			};
 			let upsertedContact = await CS.upsertContact({
 				clientId         : testClient.id,
@@ -703,21 +679,19 @@ describe('clientSuccessClient', function() {
 			expect(upsertedContact.id).to.equal(testContact.id);
 			expect(upsertedContact.firstName).to.equal(`${upsertedContactTestName}updated`);
 			expect(upsertedContact.lastName).to.equal(`${upsertedContactTestName}updated`);
-			expect(upsertedContact.customFieldValues[1].value).to.equal(`${testExtID}updated`);
+			expect(upsertedContact.customFieldValues[1].value).to.equal(`${testExternalID}updated`);
 		});
 
 		it('should not create a new contact if it has already been created under this client', async function() {
 			const newContactName  = `TEST user ${(new Date()).getTime()}`;
-			const newContactEmail = `testuser${(new Date()).getTime()}@roadmunk.com`;
+			const newContactEmail = `testuser${(new Date()).getTime()}@dev.roadmunk.com`;
 
-			// create a new contact in this test client
 			const testContactAttributes = {
 				firstName : newContactName,
 				lastName  : newContactName,
 				email     : newContactEmail,
 			};
 
-			// create the test contacts
 			const testContact1 = await CS.upsertContact({
 				clientId   : testClient.id,
 				attributes : testContactAttributes,

--- a/test/tests.js
+++ b/test/tests.js
@@ -572,12 +572,12 @@ describe('clientSuccessClient', function() {
 	});
 
 	describe('upsertContact', async function() {
+		this.timeout(15000);
 		let testClient;
 		let testContact;
 		let newContactName;
 
 		before(async function() {
-			this.timeout(15000);
 			// create test client
 			const newClientName = `TEST client ${(new Date()).getTime()}`;
 			const testExtID     = `${(new Date()).getTime()}test`;
@@ -607,12 +607,13 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should automatically create a Contact if there is an undefined contactId present in the function arguments', async function() {
-			const upsertedContactTestName = `TEST ${(new Date()).getTime()}`;
+			const upsertedContactTestName = `TEST${(new Date()).getTime()}`;
 			const upsertedContact = await CS.upsertContact({
 				clientId   : testClient.id,
 				attributes : {
 					firstName : upsertedContactTestName,
 					lastName  : upsertedContactTestName,
+					email     : `${upsertedContactTestName}@roadmunk.com`,
 				},
 			});
 			expect(upsertedContact.firstName).to.equal(upsertedContactTestName);
@@ -620,13 +621,14 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should automatically create a Contact if there is a blank contactId present in the function arguments', async function() {
-			const upsertedContactTestName = `TEST ${(new Date()).getTime()} test2`;
+			const upsertedContactTestName = `TEST${(new Date()).getTime()}test2`;
 			const upsertedContact = await CS.upsertContact({
 				clientId   : testClient.id,
 				contactId  : '',
 				attributes : {
 					firstName : upsertedContactTestName,
 					lastName  : upsertedContactTestName,
+					email     : `${upsertedContactTestName}@roadmunk.com`,
 				},
 			});
 			expect(upsertedContact.firstName).to.equal(upsertedContactTestName);
@@ -634,13 +636,13 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should automatically create a Contact if only attributes are passed in', async function() {
-			this.timeout(15000);
-			const upsertedContactTestName = `TEST ${(new Date()).getTime()} test3`;
+			const upsertedContactTestName = `TEST${(new Date()).getTime()}test3`;
 			const upsertedContact = await CS.upsertContact({
 				clientId   : testClient.id,
 				attributes : {
 					firstName : upsertedContactTestName,
 					lastName  : upsertedContactTestName,
+					email     : `${upsertedContactTestName}@roadmunk.com`,
 				},
 			});
 			expect(upsertedContact.firstName).to.equal(upsertedContactTestName);
@@ -648,13 +650,14 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should update an existing Contact if a contactId is passed', async function() {
-			const upsertedContactTestName = `TEST ${(new Date()).getTime()} test4`;
+			const upsertedContactTestName = `TEST${(new Date()).getTime()}test4`;
 			const upsertedContact = await CS.upsertContact({
 				clientId   : testClient.id,
 				contactId  : testContact.id,
 				attributes : {
 					firstName : upsertedContactTestName,
 					lastName  : upsertedContactTestName,
+					email     : `${upsertedContactTestName}@roadmunk.com`,
 				},
 			});
 			expect(upsertedContact.id).to.equal(testContact.id);
@@ -663,12 +666,12 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should create a new Contact with custom attributes', async function() {
-			this.timeout(15000);
-			const upsertedContactTestName = `TEST ${(new Date()).getTime()} test5`;
+			const upsertedContactTestName = `TEST${(new Date()).getTime()}test5`;
 			const testExtID               = `${(new Date()).getTime()}test`;
 			const contactAttributes = {
 				firstName : upsertedContactTestName,
 				lastName  : upsertedContactTestName,
+				email     : `${upsertedContactTestName}@roadmunk.com`,
 			};
 			const contactCustomAttributes = {
 				'External ID' : testExtID,
@@ -686,11 +689,12 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should update an existing Contact with custom attribtues', async function() {
-			const upsertedContactTestName = `TEST ${(new Date()).getTime()} test5`;
+			const upsertedContactTestName = `TEST${(new Date()).getTime()}test6`;
 			const testExtID               = `${(new Date()).getTime()}test`;
 			const newContactAttributes = {
 				firstName : `${upsertedContactTestName}updated`,
 				lastName  : `${upsertedContactTestName}updated`,
+				email     : `${upsertedContactTestName}@roadmunk.com`,
 			};
 			const newContactCustomAttributes = {
 				'External ID' : `${testExtID}updated`,
@@ -710,7 +714,6 @@ describe('clientSuccessClient', function() {
 		});
 
 		it('should not create a new contact if it has already been created under this client', async function() {
-			this.timeout(15000);
 			const newContactName  = `TEST user ${(new Date()).getTime()}`;
 			const newContactEmail = `testuser${(new Date()).getTime()}@roadmunk.com`;
 


### PR DESCRIPTION
We were initially unable to deploy this functionality due to there being a bug with "+" signs in emails in the ClientSuccess API.

ClientSuccess has since deployed a fix, and this PR adds functionality to work around their fix appropriately. 