### PR TITLE
404 on non-existant client contact

### DIFF
--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -213,7 +213,21 @@ JS.class(ClientSuccessClient, {
 			this.validateClientSuccessId(clientId);
 			this.validateClientSuccessId(contactId);
 
-			return this.hitClientSuccessAPI('GET', `clients/${clientId}/contacts/${contactId}/details`);
+			let foundClient;
+			try {
+				foundClient = await this.hitClientSuccessAPI('GET', `clients/${clientId}/contacts/${contactId}/details`);
+			}
+			catch (error) {
+				if (error.status === 417) {
+					// Contact was not found, return a 404 instead
+					throw new CustomError({ status : 404, message : 'Contact not found', userMessage : error.userMessage });
+				}
+				else {
+					throw new CustomError({ status : error.status, message : error.message, userMessage : error.userMessage });
+				}
+			}
+
+			return foundClient;
 		},
 
 		/**

--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -220,7 +220,7 @@ JS.class(ClientSuccessClient, {
 			catch (error) {
 				if (error.status === 417) {
 					// Contact was not found, return a 404 instead of a 417
-					// This is an issue with the ClientSuccess adapter as of 10/08/18, that will be addressed in V2 of their API
+					// This is an issue with the ClientSuccess API as of 2018-08-10, that will be addressed in V2 of their API
 					throw new CustomError({ status : 404, message : 'Contact not found', userMessage : error.userMessage });
 				}
 				else {

--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -219,7 +219,8 @@ JS.class(ClientSuccessClient, {
 			}
 			catch (error) {
 				if (error.status === 417) {
-					// Contact was not found, return a 404 instead
+					// Contact was not found, return a 404 instead of a 417
+					// This is an issue with the ClientSuccess adapter as of 10/08/18, that will be addressed in V2 of their API
 					throw new CustomError({ status : 404, message : 'Contact not found', userMessage : error.userMessage });
 				}
 				else {

--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -97,7 +97,7 @@ JS.class(ClientSuccessClient, {
 						throw new CustomError({ status : 400, message : 'Bad Request', userMessage : error.response.data.userMessage });
 					}
 					else {
-						throw new CustomError({ status : error.response.status, message : error.response.message });
+						throw new CustomError({ status : error.response.status, message : error.response.message, userMessage : error.response.data.userMessage });
 					}
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadmunk/client-success-client",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roadmunk/client-success-client",
   "description": "Client library for the ClientSuccess.com API",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Roadmunk/clientSuccessClient.git"

--- a/test/tests.js
+++ b/test/tests.js
@@ -381,7 +381,12 @@ describe('clientSuccessClient', function() {
 
 		it('should return back a 404 error object when the contact does not exist', async function() {
 			// using Client ID 90267712 that does actually exist, with a 0 contact ID that does not
-			expect(CS.getContact(90267712, 123)).to.eventually.be.rejectedWith({ status : 404 });
+			try {
+				await CS.getContact(90267712, 123);
+			}
+			catch (error) {
+				expect(error.status).to.equal(404);
+			}
 		});
 
 		it('should throw an error when we pass an invalid data type in');
@@ -667,6 +672,18 @@ describe('clientSuccessClient', function() {
 			expect(upsertedContact.firstName).to.equal(`${upsertedContactTestName}updated`);
 			expect(upsertedContact.lastName).to.equal(`${upsertedContactTestName}updated`);
 			expect(upsertedContact.customFieldValues[1].value).to.equal(`${upsertedContactTestName}updated`);
+		});
+
+		it.only('should return a 404 if the contact to be upserted does not exist in the client', async function() {
+			try {
+				await CS.upsertContact({
+					clientId  : testClient.id,
+					contactId : 123,
+				});
+			}
+			catch (error) {
+				expect(error.status).to.equal(404);
+			}
 		});
 	});
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -674,7 +674,7 @@ describe('clientSuccessClient', function() {
 			expect(upsertedContact.customFieldValues[1].value).to.equal(`${upsertedContactTestName}updated`);
 		});
 
-		it.only('should return a 404 if the contact to be upserted does not exist in the client', async function() {
+		it('should return a 404 if the contact to be upserted does not exist in the client', async function() {
 			try {
 				await CS.upsertContact({
 					clientId  : testClient.id,


### PR DESCRIPTION
Previously, when the Client did not exist, it would actually return back a 417 instead, which is inaccurate. 

This PR will transform the 417 to a 404 for better handling on the App side.

Our prior tests to detect 404 responses were incorrect, and returned a false positive. 