### PR TITLE
Bug/Added check if contact belongs to client before contact delete

### DIFF
--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -355,9 +355,13 @@ JS.class(ClientSuccessClient, {
 		 * @param  {String} contactId - Contact ID of the contact to be deleted
 		 * @return Promise<Object>    - Promise with the response from the ClientSuccess API
 		 */
-		deleteContact : function(clientId, contactId) {
+		deleteContact : async function(clientId, contactId) {
 			if (!clientId || !contactId) {
 				throw new CustomError({ status : 400, message : 'Client ID and Contact ID Required for Deletion' });
+			}
+
+			if (!(await this.doesContactBelongToClient(clientId, contactId))) {
+				throw new CustomError({ status : 404, message : 'Client not found for contact with that id' });
 			}
 
 			return this.hitClientSuccessAPI('DELETE', `clients/${clientId}/contacts/${contactId}`);
@@ -413,6 +417,24 @@ JS.class(ClientSuccessClient, {
 		validateClientSuccessId : function(clientSuccessId) {
 			if (!clientSuccessId || isNaN(parseInt(clientSuccessId))) {
 				throw new CustomError({ status : 400, message : 'Invalid ClientSuccess ID' });
+			}
+		},
+
+		/**
+		 * Check if the id of the contact passed in belongs to the client id thats passed in.
+		 * This is done through a GET api call since ClientSuccess contains this logic when
+		 * hitting this endpoint. Does not seem to also be the case with the DELETE endpoint
+		 * so this method should be used before sending a DELETE request for a contact.
+		 * @param {String} clientId  - the ID of the client the contact should be a part of
+		 * @param {String} contactId - the ID of the contact to be checked
+		 */
+		doesContactBelongToClient : async function(clientId, contactId) {
+			try {
+				const contact = await this.getContact(clientId, contactId);
+				return contact.clientId === clientId;
+			}
+			catch(err) {
+				return false;
 			}
 		},
 

--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -431,7 +431,7 @@ JS.class(ClientSuccessClient, {
 		doesContactBelongToClient : async function(clientId, contactId) {
 			try {
 				const contact = await this.getContact(clientId, contactId);
-				return contact.clientId === clientId;
+				return `${contact.clientId}` === clientId; // needs to be converted to a string since the object returned holds it as an int
 			}
 			catch(err) {
 				return false;

--- a/clientSuccessClient.js
+++ b/clientSuccessClient.js
@@ -360,9 +360,8 @@ JS.class(ClientSuccessClient, {
 				throw new CustomError({ status : 400, message : 'Client ID and Contact ID Required for Deletion' });
 			}
 
-			const response = await this.doesContactBelongToClient(clientId, contactId);
-			if (!response.isPartOfClient) {
-				throw new CustomError({ status : response.status, message : response.message });
+			if (!(await this.doesContactBelongToClient(clientId, contactId))) {
+				throw new CustomError({ status : 404, message : 'Client not found for contact with that id' });
 			}
 
 			return this.hitClientSuccessAPI('DELETE', `clients/${clientId}/contacts/${contactId}`);
@@ -431,11 +430,11 @@ JS.class(ClientSuccessClient, {
 		 */
 		doesContactBelongToClient : async function(clientId, contactId) {
 			try {
-				const isPartOfClient = (await this.getContact(clientId, contactId)).clientId === clientId;
-				return { isPartOfClient, status : isPartOfClient ? 200 : 404, message : isPartOfClient ? 'Contact belongs to client.' : 'ID of the client found does not match the ClientId passed in.' };
+				const contact = await this.getContact(clientId, contactId);
+				return contact.clientId === clientId;
 			}
 			catch(err) {
-				return { isPartOfClient : false, status : err.status, message : err.message };
+				return false;
 			}
 		},
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -760,8 +760,8 @@ describe('clientSuccessClient', function() {
 
 		it('should throw and return 400 if the clientId and/or contactId are missing', async function() {
 			const expectedError = { status : 400, message : 'Client ID and Contact ID Required for Deletion' };
-			expect(() => CS.deleteContact()).to.throw(expectedError.message).that.has.property('status').which.equals(expectedError.status);
-			expect(() => CS.deleteContact(testClient.id)).to.throw(expectedError.message).that.has.property('status').which.equals(expectedError.status);
+			await expect(CS.deleteContact()).to.be.rejected.and.eventually.include(expectedError);
+			await expect(CS.deleteContact(testClient.id)).to.be.rejected.and.eventually.include(expectedError);
 		});
 
 		it('should return 404 if the contact does not exist', async function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -754,7 +754,7 @@ describe('clientSuccessClient', function() {
 
 			await expect(CS.deleteContact(testOtherClient.id, testContact.id)).to.be.rejected.and.eventually.include({
 				status : 404,
-				message : 'Client not found for contact with that id'
+				message : 'Contact not found'
 			});
 		});
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -754,7 +754,7 @@ describe('clientSuccessClient', function() {
 
 			await expect(CS.deleteContact(testOtherClient.id, testContact.id)).to.be.rejected.and.eventually.include({
 				status : 404,
-				message : 'Contact not found'
+				message : 'Client not found for contact with that id'
 			});
 		});
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -760,8 +760,8 @@ describe('clientSuccessClient', function() {
 
 		it('should throw and return 400 if the clientId and/or contactId are missing', async function() {
 			const expectedError = { status : 400, message : 'Client ID and Contact ID Required for Deletion' };
-			await expect(CS.deleteContact()).to.be.rejected.and.eventually.include(expectedError);
-			await expect(CS.deleteContact(testClient.id)).to.be.rejected.and.eventually.include(expectedError);
+			expect(() => CS.deleteContact()).to.throw(expectedError.message).that.has.property('status').which.equals(expectedError.status);
+			expect(() => CS.deleteContact(testClient.id)).to.throw(expectedError.message).that.has.property('status').which.equals(expectedError.status);
 		});
 
 		it('should return 404 if the contact does not exist', async function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -743,6 +743,21 @@ describe('clientSuccessClient', function() {
 			expect(CS.getContact(testContact.id)).to.eventually.be.rejectedWith({ status : 404 });
 		});
 
+		it('should throw if the contactId provided is not part of the clientId passed', async function() {
+			const testOtherClientName = `TEST other user ${(new Date()).getTime()}`;
+			const testOtherClientAttributesInitial = {
+				name : testOtherClientName,
+			}
+
+			// create another client that is not linked to the contact we are trying to delete
+			const testOtherClient = await CS.createClient(testOtherClientAttributesInitial);
+
+			await expect(CS.deleteContact(testOtherClient.id, testContact.id)).to.be.rejected.and.eventually.include({
+				status : 404,
+				message : 'Client not found for contact with that id'
+			});
+		});
+
 		it('should throw and return 400 if the clientId and/or contactId are missing', async function() {
 			const expectedError = { status : 400, message : 'Client ID and Contact ID Required for Deletion' };
 			expect(() => CS.deleteContact()).to.throw(expectedError.message).that.has.property('status').which.equals(expectedError.status);


### PR DESCRIPTION
It was discovered during testing that when hitting the ClientSuccess API with a DELETE request for a contact, the contact would still be deleted even if the id of the client that was passed in was not the client the contact belonged to.

This PR just adds that extra check to make sure before deleting a contact, that the contact passed in as a parameter does indeed belong to the client that was also passed in.